### PR TITLE
fix: remediate high & critical Dependabot vulnerabilities in example code

### DIFF
--- a/examples/hello-nextjs/package.json
+++ b/examples/hello-nextjs/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@launchdarkly/node-server-sdk": "^9.10.5",
     "launchdarkly-react-client-sdk": "^3.9.0",
-    "next": "16.0.10",
+    "next": "16.2.7",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
@@ -21,7 +21,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "16.0.7",
+    "eslint-config-next": "16.2.7",
     "tailwindcss": "^4",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Summary

Upgrades `next` from `16.0.10` → `16.2.7` and `eslint-config-next` from `16.0.7` → `16.2.7` in `examples/hello-nextjs` to remediate high-severity vulnerabilities (middleware/proxy bypass, DoS via image optimizer, CSRF checks bypass, cache poisoning, and others).

No other sub-projects in this repo had high or critical vulnerabilities (`launchdarkly-ip-counter`, `percentage-rollout-distribution`, and `React-Native` all came back clean).

Link to Devin session: https://app.devin.ai/sessions/8fe095ceb6904c43b0aa3cd659e1e83c
Requested by: @pkaeding