### PR TITLE
TSS-2321: Add ld-netcheck network connectivity diagnostic tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 launchdarkly-ip-counter/all_ips.txt
 *.csv
 .vscode
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .DS_Store
 launchdarkly-ip-counter/all_ips.txt
 *.csv
+.vscode

--- a/support-network-diag-tool/README.md
+++ b/support-network-diag-tool/README.md
@@ -1,12 +1,14 @@
 # ld-netcheck
 
-A connectivity diagnostic for the LaunchDarkly SDKs. It tests whether an
-environment can reach the **streaming (init)**, **polling (init)**, and
-**events** endpoints, and — when it can't — tells you *why* and *how to fix
-it*, mapped to the failure modes LaunchDarkly endpoints actually produce.
+A connectivity diagnostic for **server-side SDKs** and **client-side JavaScript**.
+It tests whether an environment can reach the **streaming (init)**, **polling
+(init)**, and **events** endpoints, and — when it can't — tells you *why* and
+*how to fix it*, mapped to the failure modes LaunchDarkly endpoints actually
+produce.
 
-Hand this to a customer (or run it yourself) when an SDK won't initialize,
-the stream keeps reconnecting, or events aren't arriving.
+**Mobile SDKs (iOS/Android) are out of scope.** This tool runs on a host machine
+with Python/curl and cannot exercise the device TLS stack, ATS, or certificate
+pinning.
 
 There are two tiers:
 
@@ -70,8 +72,9 @@ python3 ld_netcheck.py
 python3 ld_netcheck.py --instance eu --side client
 python3 ld_netcheck.py --instance federal --side server
 
-# Test a Relay Proxy (single base URI proxies all three services)
+# Test a Relay Proxy (stream/poll/events go through relay; use --side for paths)
 python3 ld_netcheck.py --relay https://relay.internal:8030
+python3 ld_netcheck.py --relay https://relay.internal:8030 --side client
 
 # Override individual endpoints (e.g. a private instance)
 python3 ld_netcheck.py \
@@ -88,8 +91,9 @@ python3 ld_netcheck.py --sdk-key-env LD_SDK_KEY --hold 120
 python3 ld_netcheck.py --json
 ```
 
-Key flags: `--instance {commercial,eu,federal}`, `--side {server,client,mobile}`,
-`--relay`, `--stream-url/--poll-url/--events-url`, `--sdk-key-env` (preferred)
+Key flags: `--instance {commercial,eu,federal}`, `--side {server,client}`,
+`--relay`, `--stream-url/--poll-url/--poll-app-url/--events-url`,
+`--sdk-key-env` (preferred)
 or `--sdk-key`, `--hold SECONDS` (0 to skip), `--timeout SECONDS`,
 `--allow-insecure` (permit `http://`, e.g. a local relay), `--json`,
 `--no-color`.
@@ -123,10 +127,26 @@ failure. Useful for wiring into CI or a health check.
 | eu | `stream` / `sdk` / `events` `.eu.launchdarkly.com` |
 | federal | `stream` / `sdk` / `events` `.launchdarkly.us` |
 
-Client/mobile sides use `clientstream` / `clientsdk`, and mobile events use
-`mobile.launchdarkly.com` on the commercial instance. The tool does not hardcode
-IP ranges (LaunchDarkly is fronted by Fastly and AWS, and those change); it
-reports whatever the host resolves.
+| Instance | Client-side JS stream / poll / events |
+|----------|---------------------------------------|
+| commercial | `clientstream` / `clientsdk` + `app` / `events` `.launchdarkly.com` |
+| eu | `clientstream` / `clientsdk` + `app` / `events` `.eu.launchdarkly.com` |
+| federal | `clientstream` / `clientsdk` + `app` / `events` `.launchdarkly.us` |
+
+Client-side JS (`--side client`) uses `clientstream` for streaming,
+`clientsdk` and `app` for polling (both are tested — the JS SDK may use either),
+and `events` for event delivery. With `--relay`, stream/poll/events are sent
+through the Relay Proxy (v9 uses streaming and polling for init), but the direct
+`app` poll check still runs so allowlisting gaps are not missed. The tool does
+not hardcode IP ranges
+(LaunchDarkly is fronted by Fastly and AWS, and those change); it reports
+whatever the host resolves.
+
+### Mobile SDKs
+
+Not supported. Mobile endpoints (`/meval`, `/msdk/evalx`, `mobile.launchdarkly.com`)
+require diagnostics that run on or from the device itself. Do not use this tool
+for mobile SDK connectivity cases.
 
 ## Security
 

--- a/support-network-diag-tool/README.md
+++ b/support-network-diag-tool/README.md
@@ -1,0 +1,138 @@
+# ld-netcheck
+
+A connectivity diagnostic for the LaunchDarkly SDKs. It tests whether an
+environment can reach the **streaming (init)**, **polling (init)**, and
+**events** endpoints, and — when it can't — tells you *why* and *how to fix
+it*, mapped to the failure modes LaunchDarkly endpoints actually produce.
+
+Hand this to a customer (or run it yourself) when an SDK won't initialize,
+the stream keeps reconnecting, or events aren't arriving.
+
+There are two tiers:
+
+| File | Runtime | Use when |
+|------|---------|----------|
+| `ld_netcheck.py` | Python 3.8+ (standard library only) | The normal case. Full diagnosis, layered checks, JSON output. |
+| `ld-netcheck-quick.sh` | POSIX `sh` + `curl` | Locked-down hosts that won't run anything else. First-pass triage. |
+
+Both have **zero third-party dependencies**.
+
+## What it checks
+
+For each of the three endpoints it runs layered checks and stops being useful
+to go deeper once a layer fails:
+
+1. **DNS** — does the hostname resolve? (Reports the resolved IPs.)
+2. **TCP** — can it open the port (443 by default)?
+3. **TLS** — does the handshake succeed against the system trust store, and is
+   the certificate issued by a *public* CA? A trusted-but-non-public issuer or
+   an outright validation failure is flagged as likely **TLS interception**
+   (it scans the certificate for known proxy vendors — Zscaler, Palo Alto,
+   Netskope, etc.).
+4. **HTTP** — the response status is interpreted into a concrete cause
+   (see the table below).
+5. **Stream hold** — opens the SSE stream and holds it open for `--hold`
+   seconds, watching for a premature close or an idle stall. This is the check
+   that catches the single most common hard failure: a load balancer, reverse
+   proxy, or firewall silently severing the long-lived streaming connection.
+
+It also reports any `HTTP(S)_PROXY` environment variables, since an SDK that
+isn't configured to use the proxy — or a proxy that buffers/modifies SSE — is
+a frequent root cause.
+
+### How the diagnosis maps to causes
+
+| Signal | Diagnosis |
+|--------|-----------|
+| DNS / TCP failure | Egress to the domain/port is blocked; allowlist it |
+| TLS validation fails | TLS-inspecting proxy re-signing traffic, or a missing/locked-down CA bundle |
+| TLS valid but non-public issuer | A corporate root is installed; an inspecting proxy is in the path |
+| HTTP 401 | SDK key missing/incorrect (auth, not network). Without a key, 401 just means *reachable* |
+| HTTP 403 / Forbidden | Endpoint not allowlisted in the firewall or the app's Content Security Policy |
+| HTTP 404 | Wrong path/instance/SDK side |
+| HTTP 405 on events | A proxy permits GET but blocks POST; events silently fail |
+| HTTP 503 | Relay Proxy not ready yet (SDKs back off and retry) |
+| Status 0 / timeout | A reverse proxy is refusing or dropping the connection |
+| Stream closes early | A load balancer/proxy/firewall is severing the long-lived SSE connection |
+| Stream stalls (no data/keepalive) | The network is holding/buffering the connection ("received no data, assuming connection is dead") |
+
+These mappings come from the LaunchDarkly public
+[domain list](https://launchdarkly.com/docs/sdk/concepts/domain-list) and the
+internal Network Troubleshooting Checklist.
+
+## Usage — Python tool
+
+```bash
+# Commercial instance, server-side SDK defaults
+python3 ld_netcheck.py
+
+# Pick the instance and SDK side
+python3 ld_netcheck.py --instance eu --side client
+python3 ld_netcheck.py --instance federal --side server
+
+# Test a Relay Proxy (single base URI proxies all three services)
+python3 ld_netcheck.py --relay https://relay.internal:8030
+
+# Override individual endpoints (e.g. a private instance)
+python3 ld_netcheck.py \
+  --stream-url https://stream.mycompany.launchdarkly.com \
+  --poll-url   https://app.mycompany.launchdarkly.com \
+  --events-url https://events.mycompany.launchdarkly.com
+
+# Run the live authenticated stream-hold test (recommended).
+# Prefer the env-var form so the key is NOT visible in the process list:
+export LD_SDK_KEY=sdk-xxxxxxxx
+python3 ld_netcheck.py --sdk-key-env LD_SDK_KEY --hold 120
+
+# Machine-readable output to paste into a ticket (key is redacted):
+python3 ld_netcheck.py --json
+```
+
+Key flags: `--instance {commercial,eu,federal}`, `--side {server,client,mobile}`,
+`--relay`, `--stream-url/--poll-url/--events-url`, `--sdk-key-env` (preferred)
+or `--sdk-key`, `--hold SECONDS` (0 to skip), `--timeout SECONDS`,
+`--allow-insecure` (permit `http://`, e.g. a local relay), `--json`,
+`--no-color`.
+
+To exercise the stream-hold the way the SDK experiences it, run with a key and
+a `--hold` at or above your SDK's stream read timeout (server-side SDKs default
+to roughly 5 minutes / `--hold 300`).
+
+## Usage — curl triage script
+
+Configured entirely through environment variables so the SDK key never lands
+in argv:
+
+```bash
+LD_SDK_KEY=sdk-xxxxxxxx ./ld-netcheck-quick.sh
+LD_INSTANCE=eu LD_SIDE=server ./ld-netcheck-quick.sh
+LD_RELAY=https://relay.internal:8030 ./ld-netcheck-quick.sh
+LD_HOLD=120 LD_TIMEOUT=15 LD_SDK_KEY=sdk-xxxxxxxx ./ld-netcheck-quick.sh
+```
+
+## Exit codes
+
+`0` = all checks passed · `1` = at least one warning · `2` = at least one
+failure. Useful for wiring into CI or a health check.
+
+## Endpoints tested (defaults)
+
+| Instance | Server stream / poll / events |
+|----------|-------------------------------|
+| commercial | `stream` / `sdk` / `events` `.launchdarkly.com` |
+| eu | `stream` / `sdk` / `events` `.eu.launchdarkly.com` |
+| federal | `stream` / `sdk` / `events` `.launchdarkly.us` |
+
+Client/mobile sides use `clientstream` / `clientsdk`, and mobile events use
+`mobile.launchdarkly.com` on the commercial instance. The tool does not hardcode
+IP ranges (LaunchDarkly is fronted by Fastly and AWS, and those change); it
+reports whatever the host resolves.
+
+## Security
+
+See `SECURITY_REVIEW.md`. In short: standard-library/`curl`-only (no supply
+chain), the SDK key is env-preferred, redacted in all output, never logged, and
+only ever sent over a fully verified TLS connection. The one place certificate
+verification is intentionally relaxed is a read-only diagnostic that inspects
+the *presented* certificate to name a likely interception proxy — it never
+sends the key or any data over that connection.

--- a/support-network-diag-tool/SECURITY_REVIEW.md
+++ b/support-network-diag-tool/SECURITY_REVIEW.md
@@ -1,0 +1,116 @@
+# Security review — ld-netcheck
+
+Scope: `ld_netcheck.py` (v1.0.0) and `ld-netcheck-quick.sh`. This tool is meant
+to be handed to customers and run inside their networks, often by people who
+will read it before running it, so the bar is "safe to run, and obviously so."
+
+Summary: **no high or medium findings.** One low item was fixed during review.
+The design choices below were made specifically to keep the attack surface and
+the trust required to run it small.
+
+## Dependencies / supply chain
+
+- `ld_netcheck.py` imports only the Python standard library (`argparse`, `json`,
+  `os`, `socket`, `ssl`, `sys`, `dataclasses`, `http.client`, `urllib.parse`,
+  `time`). **Zero third-party packages**, so there is no dependency tree to pin
+  or audit and nothing to resolve at install time. This is the strongest form
+  of "latest published version": there is no version surface.
+- `ld-netcheck-quick.sh` uses only POSIX `sh` builtins and `curl`, both already
+  present on the hosts this targets.
+- No build step, no package manager, no network fetch of code. The files are
+  the whole tool.
+
+## SDK key handling
+
+The SDK key is the only secret the tool touches. Controls:
+
+- **Input.** Preferred path is `--sdk-key-env NAME` (Python) / `LD_SDK_KEY`
+  (shell), which keeps the key out of `argv`. `--sdk-key` exists for
+  convenience but its help text warns that argv is visible in the process list
+  and shell history. The key is optional; without it the tool still runs every
+  connectivity check (a 401 is treated as "endpoint reachable").
+- **In transit.** The key is sent only as an `Authorization` header, and only
+  over a TLS connection built with `ssl.create_default_context()` (full
+  verification, hostname checking on). The tool refuses to send to a plaintext
+  `http://` target unless `--allow-insecure` is explicitly passed (intended for
+  a local Relay Proxy on a trusted network), and even then only the user's
+  chosen target is contacted.
+- **In output.** The key is never printed or logged. Every code path that
+  surfaces it — the text header and the JSON `sdk_key` field — passes it
+  through `redact_key()`, which emits `sdk-***-xxxx`. Verified by test: the raw
+  key does not appear anywhere in `--json` output.
+- **At rest.** Nothing is written to disk.
+
+## TLS verification
+
+This is the subtlety worth being explicit about, because the tool both *relies
+on* TLS verification and *deliberately bypasses it in one narrow spot*.
+
+- All connections that send the key or read endpoint responses
+  (`check_http`, `check_stream` → `_open_raw`) use the **verified** default
+  context. A verification failure there is reported as a finding (probable TLS
+  interception or a missing CA bundle), never silently ignored.
+- `_unverified_issuer_hint()` is the **only** place verification is disabled
+  (`CERT_NONE`, `check_hostname=False`). It is reached only *after* a verified
+  handshake has already failed, and it does exactly one thing: read the
+  certificate the server presented so the tool can name the likely interception
+  vendor in its advice. **It sends no request, no Authorization header, and no
+  data** — it performs the handshake, reads the peer certificate bytes, and
+  closes. This is diagnostic-only and cannot leak the key.
+
+This split was confirmed by static check: the only `CERT_NONE`/`check_hostname`
+usage is inside that one helper, and the only `Authorization` sends are on the
+two verified paths.
+
+## Injection / unsafe execution
+
+- Python: no `eval`, `exec`, `os.system`, `subprocess`, `shell=True`,
+  `pickle`, or `input()`. The tool never shells out and never interprets remote
+  content as code — response bodies are only scanned as bytes for marker
+  strings.
+- Shell: no `eval`. All URL and header values are passed to `curl` as quoted
+  arguments. The one intentional unquoted expansion (`$HDR`) is the standard
+  POSIX idiom for conditionally adding an argument and is annotated for
+  shellcheck; the value is a fixed `-H Authorization:<key>` token with no
+  attacker-controlled content.
+
+## Network behavior / abuse potential
+
+- Outbound only. The tool connects exclusively to the targets the user
+  specifies; defaults are the published LaunchDarkly domains for the chosen
+  instance. It opens no listening socket.
+- All network operations have timeouts (`--timeout`, and `--max-time` in the
+  shell script), so it cannot hang indefinitely — verified against a
+  never-closing stream and against a fully blocked egress path.
+- The stream-hold test holds a single connection open for a bounded,
+  user-specified duration. It is not a load generator.
+- Because endpoints are user-suppliable (`--stream-url`, `--relay`, etc.), the
+  tool *can* be pointed at an arbitrary host. That is required for Relay/private
+  instances and is the operator's choice; it sends only a benign GET/POST and,
+  if supplied, the LaunchDarkly SDK key — so do not point it at an untrusted
+  host while supplying a key.
+
+## Information disclosure
+
+- Output includes resolved IPs, the negotiated TLS version, and the
+  certificate issuer/subject — all of which the operator already has access to
+  by virtue of being on the host. No private key material, no full certificate
+  dumps, no response bodies are printed.
+- The `--json` output is safe to paste into a ticket: the key is redacted and
+  no response payloads are included.
+
+## Items addressed during review
+
+- **(Low) Predictable temp file.** An earlier draft of the shell script
+  redirected `curl` stderr to `/tmp/ldnc_err.$$`, a predictable name that it
+  never actually read. Removed entirely — stderr now goes to `/dev/null`, so
+  there is no temp file to race against.
+
+## Residual notes (accept / operator awareness)
+
+- The interception-vendor list and public-CA list are heuristics for *naming*
+  the cause; they affect wording, not the pass/fail verdict (which is driven by
+  real TLS verification). A novel proxy will still be flagged as "non-public
+  issuer," just without a vendor name.
+- `--allow-insecure` exists for local Relay testing. It is off by default and
+  the only way to send anything over plaintext; the operator opts in knowingly.

--- a/support-network-diag-tool/ld-netcheck-quick.sh
+++ b/support-network-diag-tool/ld-netcheck-quick.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 # ld-netcheck-quick.sh - zero-dependency LaunchDarkly connectivity triage.
 #
-# Uses only POSIX sh + curl. Intended as the first thing to hand a customer in
-# a locked-down environment that will not run an unknown binary or interpreter.
-# It checks DNS, TCP/TLS, and HTTP reachability for the streaming (init),
+# Uses only POSIX sh + curl. It checks DNS, TCP/TLS, and HTTP reachability for the streaming (init),
 # polling (init), and events endpoints, plus a short streaming hold test.
 #
 # It never prints the SDK key. Provide it via the LD_SDK_KEY environment
@@ -17,7 +15,9 @@
 #   LD_SIDE       server | client               (default: server)
 #   LD_HOLD       stream hold seconds           (default: 10)
 #   LD_TIMEOUT    per-request timeout seconds   (default: 10)
-#   Overrides:    LD_STREAM_URL  LD_POLL_URL  LD_EVENTS_URL  (or LD_RELAY)
+#   Overrides:    LD_STREAM_URL  LD_POLL_URL  LD_POLL_APP_URL  LD_EVENTS_URL
+#                (or LD_RELAY — stream/poll/events go through relay; client-side
+#                 JS still checks app directly for the alternate poll host)
 #
 # Reference: https://launchdarkly.com/docs/sdk/concepts/domain-list
 
@@ -45,22 +45,31 @@ esac
 if [ "$SIDE" = "server" ]; then
   STREAM_HOST="stream.$DOM";       STREAM_PATH="/all"
   POLL_HOST="sdk.$DOM";            POLL_PATH="/sdk/latest-all"
+  APP_HOST="";                     APP_PATH=""
 else
   STREAM_HOST="clientstream.$DOM"; STREAM_PATH="/eval"
   POLL_HOST="clientsdk.$DOM";      POLL_PATH="/sdk/evalx"
+  APP_HOST="app.$DOM";             APP_PATH="/sdk/evalx"
 fi
-# events host: mobile uses mobile.<dom> for commercial/federal; we default to
-# the events host, which is correct for server and client-side JS.
+# events host for server and client-side JS. Mobile SDK endpoints are out of
+# scope for this tool.
 EVENTS_HOST="events.$DOM";         EVENTS_PATH="/bulk"
 
 STREAM_URL="https://$STREAM_HOST$STREAM_PATH"
 POLL_URL="https://$POLL_HOST$POLL_PATH"
+APP_URL=""
+[ -n "$APP_HOST" ] && APP_URL="https://$APP_HOST$APP_PATH"
 EVENTS_URL="https://$EVENTS_HOST$EVENTS_PATH"
 
 # Overrides
-[ -n "${LD_RELAY:-}" ] && { STREAM_URL="${LD_RELAY%/}$STREAM_PATH"; POLL_URL="${LD_RELAY%/}$POLL_PATH"; EVENTS_URL="${LD_RELAY%/}$EVENTS_PATH"; }
+[ -n "${LD_RELAY:-}" ] && {
+  STREAM_URL="${LD_RELAY%/}$STREAM_PATH"
+  POLL_URL="${LD_RELAY%/}$POLL_PATH"
+  EVENTS_URL="${LD_RELAY%/}$EVENTS_PATH"
+}
 [ -n "${LD_STREAM_URL:-}" ] && STREAM_URL="$LD_STREAM_URL"
 [ -n "${LD_POLL_URL:-}" ]   && POLL_URL="$LD_POLL_URL"
+[ -n "${LD_POLL_APP_URL:-}" ] && APP_URL="$LD_POLL_APP_URL"
 [ -n "${LD_EVENTS_URL:-}" ] && EVENTS_URL="$LD_EVENTS_URL"
 
 AUTH=""
@@ -105,6 +114,7 @@ probe() { # name method url path
 }
 
 probe "poll (init)"   GET  "$POLL_URL"
+[ -n "$APP_URL" ] && probe "poll (app)" GET "$APP_URL"
 probe "events"        POST "$EVENTS_URL"
 
 # --- Stream status + hold (single request) ----------------------------------

--- a/support-network-diag-tool/ld-netcheck-quick.sh
+++ b/support-network-diag-tool/ld-netcheck-quick.sh
@@ -1,0 +1,149 @@
+#!/bin/sh
+# ld-netcheck-quick.sh - zero-dependency LaunchDarkly connectivity triage.
+#
+# Uses only POSIX sh + curl. Intended as the first thing to hand a customer in
+# a locked-down environment that will not run an unknown binary or interpreter.
+# It checks DNS, TCP/TLS, and HTTP reachability for the streaming (init),
+# polling (init), and events endpoints, plus a short streaming hold test.
+#
+# It never prints the SDK key. Provide it via the LD_SDK_KEY environment
+# variable (NOT on the command line, which is visible in the process list and
+# shell history):
+#
+#   LD_SDK_KEY=sdk-xxxx ./ld-netcheck-quick.sh
+#
+# Options (environment variables):
+#   LD_INSTANCE   commercial | eu | federal     (default: commercial)
+#   LD_SIDE       server | client               (default: server)
+#   LD_HOLD       stream hold seconds           (default: 10)
+#   LD_TIMEOUT    per-request timeout seconds   (default: 10)
+#   Overrides:    LD_STREAM_URL  LD_POLL_URL  LD_EVENTS_URL  (or LD_RELAY)
+#
+# Reference: https://launchdarkly.com/docs/sdk/concepts/domain-list
+
+set -u
+
+INSTANCE="${LD_INSTANCE:-commercial}"
+SIDE="${LD_SIDE:-server}"
+HOLD="${LD_HOLD:-10}"
+TIMEOUT="${LD_TIMEOUT:-10}"
+KEY="${LD_SDK_KEY:-}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required but was not found in PATH." >&2
+  exit 3
+fi
+
+# --- Resolve endpoints ------------------------------------------------------
+case "$INSTANCE" in
+  commercial) DOM="launchdarkly.com" ;;
+  eu)         DOM="eu.launchdarkly.com" ;;
+  federal)    DOM="launchdarkly.us" ;;
+  *) echo "Unknown LD_INSTANCE: $INSTANCE" >&2; exit 3 ;;
+esac
+
+if [ "$SIDE" = "server" ]; then
+  STREAM_HOST="stream.$DOM";       STREAM_PATH="/all"
+  POLL_HOST="sdk.$DOM";            POLL_PATH="/sdk/latest-all"
+else
+  STREAM_HOST="clientstream.$DOM"; STREAM_PATH="/eval"
+  POLL_HOST="clientsdk.$DOM";      POLL_PATH="/sdk/evalx"
+fi
+# events host: mobile uses mobile.<dom> for commercial/federal; we default to
+# the events host, which is correct for server and client-side JS.
+EVENTS_HOST="events.$DOM";         EVENTS_PATH="/bulk"
+
+STREAM_URL="https://$STREAM_HOST$STREAM_PATH"
+POLL_URL="https://$POLL_HOST$POLL_PATH"
+EVENTS_URL="https://$EVENTS_HOST$EVENTS_PATH"
+
+# Overrides
+[ -n "${LD_RELAY:-}" ] && { STREAM_URL="${LD_RELAY%/}$STREAM_PATH"; POLL_URL="${LD_RELAY%/}$POLL_PATH"; EVENTS_URL="${LD_RELAY%/}$EVENTS_PATH"; }
+[ -n "${LD_STREAM_URL:-}" ] && STREAM_URL="$LD_STREAM_URL"
+[ -n "${LD_POLL_URL:-}" ]   && POLL_URL="$LD_POLL_URL"
+[ -n "${LD_EVENTS_URL:-}" ] && EVENTS_URL="$LD_EVENTS_URL"
+
+AUTH=""
+[ -n "$KEY" ] && AUTH="$KEY"
+
+echo "ld-netcheck-quick  instance=$INSTANCE side=$SIDE hold=${HOLD}s"
+if [ -n "$KEY" ]; then echo "sdk-key: [provided]"; else echo "sdk-key: (none - 401 means reachable)"; fi
+echo "------------------------------------------------------------------------"
+
+curl_code_to_text() {
+  case "$1" in
+    6)  echo "DNS resolution failed (host could not be resolved)" ;;
+    7)  echo "TCP connect failed (firewall likely blocking egress)" ;;
+    28) echo "timed out (no response - proxy may be dropping the connection)" ;;
+    35) echo "TLS connect error (handshake reset)" ;;
+    60) echo "TLS certificate not trusted (inspecting proxy or missing CA bundle)" ;;
+    *)  echo "curl error $1" ;;
+  esac
+}
+
+probe() { # name method url path
+  name="$1"; method="$2"; url="$3"
+  set -- -sS -o /dev/null -w '%{http_code}' --max-time "$TIMEOUT" -A "ld-netcheck-quick"
+  [ -n "$AUTH" ] && set -- "$@" -H "Authorization: $AUTH"
+  if [ "$method" = "POST" ]; then set -- "$@" -X POST -H "Content-Type: application/json" --data '[]'; fi
+  code=$(curl "$@" "$url" 2>/dev/null); rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL  $name: $(curl_code_to_text "$rc")"
+    return
+  fi
+  case "$code" in
+    200|202) echo "PASS  $name: HTTP $code" ;;
+    401) if [ -n "$AUTH" ]; then echo "FAIL  $name: HTTP 401 (SDK key wrong for this environment/instance)";
+         else echo "PASS  $name: HTTP 401 (endpoint reachable; set LD_SDK_KEY to test auth)"; fi ;;
+    403) echo "FAIL  $name: HTTP 403 (endpoint not allowlisted in firewall/CSP)" ;;
+    404) echo "WARN  $name: HTTP 404 (wrong path/instance/side?)" ;;
+    405) echo "FAIL  $name: HTTP 405 (POST blocked - events will silently fail)" ;;
+    503) echo "WARN  $name: HTTP 503 (Relay not ready / retrying)" ;;
+    5*)  echo "WARN  $name: HTTP $code (server-side error; capture and contact Support)" ;;
+    *)   echo "WARN  $name: HTTP $code" ;;
+  esac
+}
+
+probe "poll (init)"   GET  "$POLL_URL"
+probe "events"        POST "$EVENTS_URL"
+
+# --- Stream status + hold (single request) ----------------------------------
+# The streaming endpoint is a long-lived SSE connection, so a normal status
+# probe never returns. Instead we open it and hold for $HOLD seconds:
+#   - curl aborted by --max-time (rc 28) with HTTP 200 = stayed open (good)
+#   - clean close (rc 0) before the hold elapsed = something severed it (bad)
+#   - 401/403/etc. come back immediately and are interpreted as usual
+echo "------------------------------------------------------------------------"
+echo "Opening stream and holding for ${HOLD}s ..."
+HDR=""
+[ -n "$AUTH" ] && HDR="-H Authorization:$AUTH"
+start=$(date +%s)
+# shellcheck disable=SC2086
+code=$(curl -sS -N --max-time "$HOLD" -A "ld-netcheck-quick" -H "Accept: text/event-stream" $HDR \
+  -o /dev/null -w '%{http_code}' "$STREAM_URL" 2>/dev/null)
+rc=$?
+end=$(date +%s)
+elapsed=$((end - start))
+case "$code" in
+  200)
+    if [ "$rc" -eq 28 ]; then
+      echo "PASS  stream (init): HTTP 200, held ${HOLD}s without interruption"
+    elif [ "$rc" -eq 0 ] && [ "$elapsed" -lt "$HOLD" ]; then
+      echo "FAIL  stream (init): HTTP 200 but connection closed after ~${elapsed}s (< ${HOLD}s) - a load balancer/proxy/firewall is severing the long-lived SSE connection"
+    else
+      echo "PASS  stream (init): HTTP 200 (held ~${elapsed}s)"
+    fi ;;
+  401) if [ -n "$AUTH" ]; then echo "FAIL  stream (init): HTTP 401 (SDK key wrong for this environment/instance)";
+       else echo "PASS  stream (init): HTTP 401 (endpoint reachable; set LD_SDK_KEY to test the live stream)"; fi ;;
+  403) echo "FAIL  stream (init): HTTP 403 (endpoint not allowlisted in firewall/CSP)" ;;
+  000) echo "FAIL  stream (init): $(curl_code_to_text "$rc")" ;;
+  5*)  echo "WARN  stream (init): HTTP $code (server-side error; capture and contact Support)" ;;
+  *)   echo "WARN  stream (init): HTTP $code" ;;
+esac
+
+echo "------------------------------------------------------------------------"
+echo "If you saw FAIL on TLS: a TLS-inspecting proxy is likely re-signing"
+echo "traffic. Exempt the LaunchDarkly domains from inspection, or install the"
+echo "corporate root CA into the client trust store."
+echo "If you saw 403 / connect failures: allowlist the LaunchDarkly domain list"
+echo "for the $INSTANCE instance: https://launchdarkly.com/docs/sdk/concepts/domain-list"

--- a/support-network-diag-tool/ld_netcheck.py
+++ b/support-network-diag-tool/ld_netcheck.py
@@ -1,0 +1,740 @@
+#!/usr/bin/env python3
+"""
+ld-netcheck - LaunchDarkly SDK connectivity diagnostic.
+
+Tests whether an environment can reach the LaunchDarkly streaming (init),
+polling (init), and events endpoints, and explains how to unblock them when
+it cannot. Standard library only - no third-party dependencies.
+
+The checks and remediation mapping are grounded in the LaunchDarkly public
+domain list (https://launchdarkly.com/docs/sdk/concepts/domain-list) and the
+internal Network Troubleshooting Checklist failure modes:
+
+  401              -> SDK key missing/incorrect (auth, not network)
+  403 / Forbidden  -> endpoint not allowlisted in firewall or CSP
+  status 0/timeout -> reverse proxy refusing long-lived connections
+  invalid PUT data -> reverse proxy injecting/modifying HTTP headers
+  SSL/cert error   -> TLS-inspecting proxy or missing/locked-down CA bundle
+  relay 503        -> Relay Proxy not ready (SDK backs off and retries)
+  idle stream drop -> network/proxy severing the long-lived SSE connection
+
+Usage:
+  python3 ld_netcheck.py                       # commercial, server-side defaults
+  python3 ld_netcheck.py --instance eu --side client
+  python3 ld_netcheck.py --relay https://relay.internal:8030
+  python3 ld_netcheck.py --sdk-key-env LD_SDK_KEY --hold 120
+  python3 ld_netcheck.py --json
+"""
+
+import argparse
+import json
+import os
+import socket
+import ssl
+import sys
+import time
+from dataclasses import dataclass, field, asdict
+from http.client import HTTPSConnection, HTTPConnection
+from urllib.parse import urlsplit
+
+VERSION = "1.0.0"
+
+# --- Endpoint presets -------------------------------------------------------
+# Paths used by the real SDKs for the initial flag payload and events.
+PATHS = {
+    "server": {"stream": "/all", "poll": "/sdk/latest-all", "events": "/bulk"},
+    # Client/mobile init paths are context-specific; for a connectivity probe
+    # we hit the service root, which is enough to exercise DNS/TCP/TLS/HTTP.
+    "client": {"stream": "/eval", "poll": "/sdk/evalx", "events": "/bulk"},
+    "mobile": {"stream": "/meval", "poll": "/msdk/evalx", "events": "/mobile"},
+}
+
+INSTANCES = {
+    "commercial": {
+        "server": {"stream": "https://stream.launchdarkly.com",
+                   "poll": "https://sdk.launchdarkly.com",
+                   "events": "https://events.launchdarkly.com"},
+        "client": {"stream": "https://clientstream.launchdarkly.com",
+                   "poll": "https://clientsdk.launchdarkly.com",
+                   "events": "https://events.launchdarkly.com"},
+        "mobile": {"stream": "https://clientstream.launchdarkly.com",
+                   "poll": "https://clientsdk.launchdarkly.com",
+                   "events": "https://mobile.launchdarkly.com"},
+    },
+    "eu": {
+        "server": {"stream": "https://stream.eu.launchdarkly.com",
+                   "poll": "https://sdk.eu.launchdarkly.com",
+                   "events": "https://events.eu.launchdarkly.com"},
+        "client": {"stream": "https://clientstream.eu.launchdarkly.com",
+                   "poll": "https://clientsdk.eu.launchdarkly.com",
+                   "events": "https://events.eu.launchdarkly.com"},
+        "mobile": {"stream": "https://clientstream.eu.launchdarkly.com",
+                   "poll": "https://clientsdk.eu.launchdarkly.com",
+                   "events": "https://events.eu.launchdarkly.com"},
+    },
+    "federal": {
+        "server": {"stream": "https://stream.launchdarkly.us",
+                   "poll": "https://sdk.launchdarkly.us",
+                   "events": "https://events.launchdarkly.us"},
+        "client": {"stream": "https://clientstream.launchdarkly.us",
+                   "poll": "https://clientsdk.launchdarkly.us",
+                   "events": "https://events.launchdarkly.us"},
+        "mobile": {"stream": "https://clientstream.launchdarkly.us",
+                   "poll": "https://clientsdk.launchdarkly.us",
+                   "events": "https://events.launchdarkly.us"},
+    },
+}
+
+# Public CA organizations we recognize. If a cert validates against the system
+# trust store but its issuer is NOT one of these, a corporate root is likely
+# installed (TLS interception with a trusted root).
+PUBLIC_CA_MARKERS = [
+    "DigiCert", "Let's Encrypt", "ISRG", "GlobalSign", "Amazon", "Sectigo",
+    "Comodo", "GoDaddy", "Google Trust Services", "GTS", "Entrust",
+    "Cloudflare", "Fastly", "Apple Public", "Microsoft", "Baltimore",
+    "USERTrust", "Starfield", "Certum", "Buypass", "IdenTrust",
+]
+
+# Known TLS-interception / forward-proxy vendor signatures.
+INTERCEPTION_MARKERS = [
+    "Zscaler", "Palo Alto", "PAN-", "Fortinet", "FortiGate", "Forcepoint",
+    "Blue Coat", "Symantec Web", "Cisco Umbrella", "Cisco", "Netskope",
+    "McAfee Web", "Sophos", "Check Point", "Trend Micro", "Squid",
+    "Proxy", "SSL Inspection", "Decrypt", "MITM", "Trustwave", "Barracuda",
+]
+
+GREEN, YELLOW, RED, DIM, BOLD, RESET = (
+    "\033[32m", "\033[33m", "\033[31m", "\033[2m", "\033[1m", "\033[0m")
+
+PASS, WARN, FAIL, INFO = "PASS", "WARN", "FAIL", "INFO"
+
+
+@dataclass
+class Check:
+    name: str
+    status: str = INFO
+    detail: str = ""
+    suggestions: list = field(default_factory=list)
+
+
+@dataclass
+class TargetResult:
+    label: str          # e.g. "stream (init)"
+    url: str
+    host: str = ""
+    port: int = 443
+    checks: list = field(default_factory=list)
+
+    def add(self, c: Check):
+        self.checks.append(c)
+
+    @property
+    def worst(self):
+        order = {FAIL: 3, WARN: 2, PASS: 1, INFO: 0}
+        return max((c.status for c in self.checks), key=lambda s: order[s],
+                   default=INFO)
+
+
+def color_for(status, use_color):
+    if not use_color:
+        return ""
+    return {PASS: GREEN, WARN: YELLOW, FAIL: RED, INFO: DIM}.get(status, "")
+
+
+def redact_key(key):
+    if not key:
+        return "(none)"
+    if len(key) <= 8:
+        return "***"
+    return key[:4] + "***" + key[-4:]
+
+
+# --- Individual checks ------------------------------------------------------
+
+def check_dns(host, timeout):
+    c = Check("DNS resolution")
+    try:
+        socket.setdefaulttimeout(timeout)
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+        ips = sorted({i[4][0] for i in infos})
+        c.status = PASS
+        c.detail = "resolved to " + ", ".join(ips)
+    except Exception as e:  # noqa: BLE001
+        c.status = FAIL
+        c.detail = f"could not resolve {host}: {e}"
+        c.suggestions.append(
+            f"DNS for {host} is failing. Confirm the host can reach your "
+            "resolver and that {host} (and the rest of the LaunchDarkly "
+            "domain list) is not blocked at the DNS layer.".format(host=host))
+    finally:
+        socket.setdefaulttimeout(None)
+    return c, (c.status == PASS)
+
+
+def check_tcp(host, port, timeout):
+    c = Check(f"TCP connect :{port}")
+    t0 = time.time()
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            pass
+        c.status = PASS
+        c.detail = f"connected in {int((time.time() - t0) * 1000)} ms"
+    except Exception as e:  # noqa: BLE001
+        c.status = FAIL
+        c.detail = f"cannot open TCP {host}:{port}: {e}"
+        c.suggestions.append(
+            f"Egress to {host}:{port} is blocked. Allow outbound TCP {port} "
+            f"to {host} in the firewall, or route it through your proxy.")
+    return c, (c.status == PASS)
+
+
+def _scan_markers(blob, markers):
+    found = []
+    low = blob.lower()
+    for m in markers:
+        if m.lower() in low:
+            found.append(m)
+    return found
+
+
+def check_tls(host, port, timeout):
+    """Verified handshake plus an unverified inspection pass for MITM hints."""
+    c = Check("TLS handshake")
+    issuer_org = ""
+    try:
+        ctx = ssl.create_default_context()
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            with ctx.wrap_socket(sock, server_hostname=host) as ss:
+                cert = ss.getpeercert() or {}
+                version = ss.version()
+                issuer = dict(x[0] for x in cert.get("issuer", ()))
+                issuer_org = issuer.get("organizationName", "") or \
+                    issuer.get("commonName", "")
+        c.status = PASS
+        c.detail = f"{version}, cert issued by '{issuer_org or 'unknown'}'"
+        if version and version < "TLSv1.2":
+            c.status = WARN
+            c.detail += " (below TLS 1.2)"
+            c.suggestions.append(
+                "Negotiated TLS version is below 1.2. LaunchDarkly requires "
+                "modern TLS; update the client/proxy TLS configuration.")
+        # Trusted, but issued by something we don't recognize as a public CA?
+        if issuer_org and not _scan_markers(issuer_org, PUBLIC_CA_MARKERS):
+            vendor = _scan_markers(issuer_org, INTERCEPTION_MARKERS)
+            c.status = WARN
+            hint = f" ({vendor[0]})" if vendor else ""
+            c.detail += " - non-public issuer; TLS interception likely" + hint
+            c.suggestions.append(
+                "The certificate validated but was issued by a non-public CA "
+                f"('{issuer_org}'). A TLS-inspecting proxy{hint} is almost "
+                "certainly in the path. Inspecting proxies often rewrite or "
+                "buffer the streaming response and break the 'put' event. "
+                "Either exempt the LaunchDarkly domains from TLS inspection, "
+                "or ensure the proxy passes Server-Sent Events through "
+                "unbuffered and unmodified.")
+        return c, True
+    except ssl.SSLCertVerificationError as e:
+        c.status = FAIL
+        c.detail = f"certificate did not validate: {e.verify_message or e}"
+        # Inspect the presented cert without verifying, for a vendor hint.
+        vendor_hint = _unverified_issuer_hint(host, port, timeout)
+        c.suggestions.append(
+            "TLS verification failed. This is the classic signature of a "
+            "TLS-inspecting proxy presenting a certificate your trust store "
+            "does not recognize, or a missing/locked-down CA bundle." +
+            (f" Presented certificate looks like: {vendor_hint}." if vendor_hint
+             else "") +
+            " Fix by installing the corporate root CA into the client trust "
+            "store, or exempt the LaunchDarkly domains from TLS interception.")
+        return c, False
+    except Exception as e:  # noqa: BLE001
+        c.status = FAIL
+        c.detail = f"TLS handshake failed: {e}"
+        c.suggestions.append(
+            f"TLS to {host}:{port} failed before validation. A firewall or "
+            "proxy may be resetting the connection. Confirm outbound 443 and "
+            "that the proxy supports TLS to this host.")
+        return c, False
+
+
+def _unverified_issuer_hint(host, port, timeout):
+    """Diagnostic only: peek at the presented cert without trusting it."""
+    try:
+        uctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        uctx.check_hostname = False
+        uctx.verify_mode = ssl.CERT_NONE
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            with uctx.wrap_socket(sock, server_hostname=host) as ss:
+                der = ss.getpeercert(binary_form=True) or b""
+        text = der.decode("latin-1", "ignore")
+        vendor = _scan_markers(text, INTERCEPTION_MARKERS)
+        if vendor:
+            return vendor[0]
+        return "an untrusted / unknown issuer"
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _new_connection(url, timeout, allow_insecure):
+    parts = urlsplit(url)
+    host = parts.hostname
+    port = parts.port or (443 if parts.scheme == "https" else 80)
+    if parts.scheme == "https":
+        ctx = ssl.create_default_context()
+        return HTTPSConnection(host, port, timeout=timeout, context=ctx), parts
+    if not allow_insecure:
+        raise ValueError("refusing plaintext HTTP without --allow-insecure")
+    return HTTPConnection(host, port, timeout=timeout), parts
+
+
+def _proxy_response_hint(headers):
+    hints = []
+    for h in ("via", "x-cache", "x-forwarded-for", "proxy-connection",
+              "x-served-by", "server"):
+        v = headers.get(h)
+        if v:
+            hints.append(f"{h}={v}")
+    return "; ".join(hints)
+
+
+def interpret_status(c, code, label, key, proxy):
+    """Map an HTTP status to a check status + remediation, per the internal
+    Network Troubleshooting Checklist failure modes."""
+    detail = f"HTTP {code}"
+    if proxy:
+        detail += f"  [{proxy}]"
+    c.detail = detail
+
+    if code in (200, 202):
+        c.status = PASS
+    elif code == 401:
+        c.status = PASS if not key else FAIL
+        if not key:
+            c.detail += "  (endpoint reachable; pass an SDK key to test auth)"
+        else:
+            c.suggestions.append(
+                "401 with a key supplied means the SDK key is wrong for this "
+                "environment/instance. Verify the key against the dashboard.")
+    elif code == 403:
+        c.status = FAIL
+        c.suggestions.append(
+            f"403/Forbidden on {label} means the endpoint is not allowlisted "
+            "in the network firewall and/or the application Content Security "
+            "Policy. Allowlist the LaunchDarkly domain list for this instance.")
+    elif code == 404:
+        c.status = WARN
+        c.suggestions.append(
+            f"404 on {label}. The path or instance may be wrong for this SDK "
+            "type. Confirm you are testing the correct instance "
+            "(commercial/EU/federal) and SDK side (server/client/mobile).")
+    elif code == 405:
+        c.status = FAIL
+        c.suggestions.append(
+            f"405 Method Not Allowed on {label}. A firewall/proxy may permit "
+            "GET but block POST; events are sent with POST and will silently "
+            "fail. Allow POST to the events endpoint.")
+    elif code == 503:
+        c.status = WARN
+        c.suggestions.append(
+            "503 - if this is a Relay Proxy it is not in a ready state yet; "
+            "SDKs back off and retry. If it persists, check Relay health.")
+    elif 500 <= code < 600:
+        c.status = WARN
+        c.suggestions.append(
+            f"{code} from the endpoint directly (not a Relay Proxy) should be "
+            "rare. If it persists, capture the response and contact Support.")
+    else:
+        c.status = WARN
+    if proxy and ("via=" in proxy or "proxy-connection=" in proxy):
+        c.suggestions.append(
+            "A proxy was detected in the response headers. Ensure it does not "
+            "modify or add HTTP headers on the stream (a known cause of "
+            "'invalid data in PUT' / 'malformed JSON in event stream').")
+    return c
+
+
+def check_http(label, url, path, method, key, timeout, allow_insecure):
+    c = Check(f"HTTP {method} {label}")
+    body = b"[]" if method == "POST" else None
+    hdrs = {"User-Agent": f"ld-netcheck/{VERSION}", "Accept": "*/*"}
+    if key:
+        hdrs["Authorization"] = key
+    if method == "POST":
+        hdrs["Content-Type"] = "application/json"
+    try:
+        conn, parts = _new_connection(url, timeout, allow_insecure)
+        full = (parts.path.rstrip("/") + path) if parts.path not in ("", "/") \
+            else path
+        conn.request(method, full or "/", body=body, headers=hdrs)
+        resp = conn.getresponse()
+        code = resp.status
+        proxy = _proxy_response_hint(
+            {k.lower(): v for k, v in resp.getheaders()})
+        resp.read(2048)  # bounded read; these are short responses
+        conn.close()
+    except socket.timeout:
+        c.status = FAIL
+        c.detail = "request timed out (no response)"
+        c.suggestions.append(
+            f"No HTTP response from {label}. A reverse proxy/web server in the "
+            "path may be refusing or silently dropping the connection. Confirm "
+            "it permits long-lived connections to LaunchDarkly and is not "
+            "buffering the response.")
+        return c
+    except Exception as e:  # noqa: BLE001
+        c.status = FAIL
+        c.detail = f"request failed: {e}"
+        c.suggestions.append(
+            f"HTTP to {label} failed: {e}. Check firewall, proxy and TLS path.")
+        return c
+    return interpret_status(c, code, label, key, proxy)
+
+
+def _open_raw(url, path, key, timeout, allow_insecure):
+    """Open a raw (optionally TLS) socket and send a streaming GET. Returns
+    (sock, status_code, headers_dict, leftover_body_bytes)."""
+    parts = urlsplit(url)
+    host = parts.hostname
+    port = parts.port or (443 if parts.scheme == "https" else 80)
+    raw = socket.create_connection((host, port), timeout=timeout)
+    if parts.scheme == "https":
+        ctx = ssl.create_default_context()
+        sock = ctx.wrap_socket(raw, server_hostname=host)
+    else:
+        if not allow_insecure:
+            raw.close()
+            raise ValueError("refusing plaintext HTTP without --allow-insecure")
+        sock = raw
+    base = parts.path.rstrip("/") if parts.path not in ("", "/") else ""
+    req_path = (base + path) or "/"
+    lines = [f"GET {req_path} HTTP/1.1",
+             f"Host: {host}",
+             f"User-Agent: ld-netcheck/{VERSION}",
+             "Accept: text/event-stream",
+             "Cache-Control: no-cache",
+             "Connection: keep-alive"]
+    if key:
+        lines.append(f"Authorization: {key}")
+    sock.sendall(("\r\n".join(lines) + "\r\n\r\n").encode())
+
+    sock.settimeout(timeout)
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        buf += chunk
+    head, _, leftover = buf.partition(b"\r\n\r\n")
+    head_lines = head.decode("latin-1", "ignore").split("\r\n")
+    status_line = head_lines[0] if head_lines else ""
+    parts_sl = status_line.split(" ", 2)
+    code = int(parts_sl[1]) if len(parts_sl) > 1 and parts_sl[1].isdigit() else 0
+    headers = {}
+    for hl in head_lines[1:]:
+        if ":" in hl:
+            k, v = hl.split(":", 1)
+            headers[k.strip().lower()] = v.strip()
+    return sock, code, headers, leftover
+
+
+def check_stream(url, path, key, hold, timeout, allow_insecure):
+    """Open the SSE stream, interpret status, and (if 200 and hold>0) hold the
+    connection open to detect premature close or idle drop. Returns a list of
+    Check objects."""
+    status_c = Check("HTTP GET stream (init)")
+    try:
+        sock, code, headers, leftover = _open_raw(
+            url, path, key, timeout, allow_insecure)
+    except socket.timeout:
+        status_c.status = FAIL
+        status_c.detail = "stream request timed out (no response)"
+        status_c.suggestions.append(
+            "No response opening the stream. A reverse proxy/web server may be "
+            "refusing or silently dropping the long-lived connection. Confirm "
+            "it allows long-lived connections to LaunchDarkly and does not "
+            "buffer the response.")
+        return [status_c]
+    except Exception as e:  # noqa: BLE001
+        status_c.status = FAIL
+        status_c.detail = f"stream request failed: {e}"
+        status_c.suggestions.append(
+            f"Opening the stream failed: {e}. Check firewall, proxy and TLS.")
+        return [status_c]
+
+    proxy = _proxy_response_hint(headers)
+    interpret_status(status_c, code, "stream", key, proxy)
+
+    if code != 200 or hold <= 0:
+        try:
+            sock.close()
+        except Exception:  # noqa: BLE001
+            pass
+        return [status_c]
+
+    # 200 OK: hold the connection and watch for premature close / idle stall.
+    hold_c = Check(f"Stream hold {hold}s")
+    start = time.time()
+    deadline = start + hold
+    first_data_at = None
+    last_data = start
+    closed = False
+    stalled = False
+    read_timeout = max(1.0, min(timeout, hold))
+    sock.settimeout(read_timeout)
+
+    def note(chunk):
+        nonlocal first_data_at, last_data
+        last_data = time.time()
+        if first_data_at is None and (b"data:" in chunk or b"event:" in chunk):
+            first_data_at = time.time()
+
+    if leftover:
+        note(leftover)
+
+    while time.time() < deadline:
+        try:
+            chunk = sock.recv(1024)
+        except socket.timeout:
+            if time.time() - last_data > read_timeout * 2:
+                stalled = True
+                break
+            continue
+        except Exception:  # noqa: BLE001
+            closed = True
+            break
+        if chunk == b"":
+            closed = True
+            break
+        note(chunk)
+    try:
+        sock.close()
+    except Exception:  # noqa: BLE001
+        pass
+
+    held = time.time() - start
+    if closed and held < hold - 0.5:
+        hold_c.status = FAIL
+        hold_c.detail = f"connection closed after ~{int(held)}s (< {hold}s)"
+        hold_c.suggestions.append(
+            "The streaming connection was severed early. A load balancer, "
+            "reverse proxy, or firewall is closing the long-lived SSE "
+            "connection. Raise idle/connection timeouts above the stream "
+            "heartbeat interval and ensure SSE is passed through unbuffered.")
+    elif stalled:
+        hold_c.status = WARN
+        hold_c.detail = "no data/keepalive received for an extended period"
+        hold_c.suggestions.append(
+            "The stream stalled with no data or keepalive. This matches "
+            "'received no data, assuming connection is dead'. The network is "
+            "likely holding or buffering the connection. Disable response "
+            "buffering for SSE on the proxy/load balancer.")
+    else:
+        hold_c.status = PASS
+        ttfd = (f", first data in {int((first_data_at - start) * 1000)} ms"
+                if first_data_at else "")
+        hold_c.detail = f"held {int(held)}s without interruption{ttfd}"
+    return [status_c, hold_c]
+
+
+def check_env_proxy():
+    c = Check("Proxy environment")
+    found = {}
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy",
+                "https_proxy", "no_proxy"):
+        v = os.environ.get(var)
+        if v:
+            found[var] = v
+    if not found:
+        c.status = INFO
+        c.detail = "no proxy environment variables set"
+    else:
+        c.status = INFO
+        c.detail = "; ".join(f"{k}={v}" for k, v in found.items())
+        c.suggestions.append(
+            "Proxy environment variables are set. Confirm your SDK is "
+            "configured to use the proxy (many SDKs do not read these "
+            "automatically), that the proxy permits long-lived SSE streaming, "
+            "and that it does not modify HTTP headers on the stream.")
+    return c
+
+
+# --- Orchestration ----------------------------------------------------------
+
+def build_targets(args):
+    targets = {}
+    if args.relay:
+        base = args.relay.rstrip("/")
+        targets = {"stream": base, "poll": base, "events": base}
+        side = "server"
+    else:
+        side = args.side
+        if args.stream_url or args.poll_url or args.events_url:
+            preset = INSTANCES[args.instance][side]
+            targets = {
+                "stream": args.stream_url or preset["stream"],
+                "poll": args.poll_url or preset["poll"],
+                "events": args.events_url or preset["events"],
+            }
+        else:
+            targets = dict(INSTANCES[args.instance][side])
+    return targets, side
+
+
+def run(args):
+    key = None
+    if args.sdk_key_env:
+        key = os.environ.get(args.sdk_key_env)
+        if not key:
+            print(f"warning: env var {args.sdk_key_env} is empty/unset",
+                  file=sys.stderr)
+    elif args.sdk_key:
+        key = args.sdk_key
+
+    targets, side = build_targets(args)
+    paths = PATHS[side]
+    results = []
+
+    for kind in ("stream", "poll", "events"):
+        url = targets[kind]
+        parts = urlsplit(url)
+        host = parts.hostname
+        port = parts.port or (443 if parts.scheme == "https" else 80)
+        label = {"stream": "stream (init)", "poll": "poll (init)",
+                 "events": "events"}[kind]
+        tr = TargetResult(label=label, url=url, host=host, port=port)
+
+        dns_c, ok = check_dns(host, args.timeout)
+        tr.add(dns_c)
+        if ok:
+            tcp_c, ok = check_tcp(host, port, args.timeout)
+            tr.add(tcp_c)
+        if ok and parts.scheme == "https":
+            tls_c, ok = check_tls(host, port, args.timeout)
+            tr.add(tls_c)
+        if ok:
+            if kind == "stream":
+                for sc in check_stream(url, paths[kind], key, args.hold,
+                                       args.timeout, args.allow_insecure):
+                    tr.add(sc)
+            else:
+                method = "POST" if kind == "events" else "GET"
+                tr.add(check_http(kind, url, paths[kind], method, key,
+                                  args.timeout, args.allow_insecure))
+        results.append(tr)
+
+    env_c = check_env_proxy()
+    return results, env_c, key, side
+
+
+# --- Reporting --------------------------------------------------------------
+
+def print_text(results, env_c, key, side, args):
+    use_color = (not args.no_color) and sys.stdout.isatty()
+    b = BOLD if use_color else ""
+    r = RESET if use_color else ""
+
+    print(f"{b}ld-netcheck {VERSION}{r}  "
+          f"instance={args.instance if not args.relay else 'relay'} "
+          f"side={side} sdk-key={redact_key(key)} hold={args.hold}s")
+    print("=" * 72)
+
+    suggestions = []
+    for tr in results:
+        wc = color_for(tr.worst, use_color)
+        print(f"\n{wc}[{tr.worst}]{r} {b}{tr.label}{r}  {DIM if use_color else ''}{tr.url}{r}")
+        for c in tr.checks:
+            cc = color_for(c.status, use_color)
+            print(f"    {cc}{c.status:<4}{r} {c.name}: {c.detail}")
+            for s in c.suggestions:
+                suggestions.append(s)
+
+    cc = color_for(env_c.status, use_color)
+    print(f"\n{cc}{env_c.status:<4}{r} {env_c.name}: {env_c.detail}")
+    for s in env_c.suggestions:
+        suggestions.append(s)
+
+    if suggestions:
+        print(f"\n{b}Suggestions to unblock:{r}")
+        seen = set()
+        n = 1
+        for s in suggestions:
+            if s in seen:
+                continue
+            seen.add(s)
+            print(f"  {n}. {s}")
+            n += 1
+    else:
+        print(f"\n{GREEN if use_color else ''}All checks passed - no action "
+              f"needed.{r}")
+
+    print("\nReference: LaunchDarkly domain list - "
+          "https://launchdarkly.com/docs/sdk/concepts/domain-list")
+
+
+def print_json(results, env_c, key, side, args):
+    out = {
+        "tool": "ld-netcheck",
+        "version": VERSION,
+        "instance": args.instance if not args.relay else "relay",
+        "side": side,
+        "sdk_key": redact_key(key),
+        "hold_seconds": args.hold,
+        "targets": [],
+    }
+    for tr in results:
+        out["targets"].append({
+            "label": tr.label, "url": tr.url, "host": tr.host,
+            "port": tr.port, "result": tr.worst,
+            "checks": [asdict(c) for c in tr.checks],
+        })
+    out["proxy_environment"] = asdict(env_c)
+    print(json.dumps(out, indent=2))
+
+
+def exit_code(results):
+    for tr in results:
+        if tr.worst == FAIL:
+            return 2
+    for tr in results:
+        if tr.worst == WARN:
+            return 1
+    return 0
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        prog="ld-netcheck",
+        description="Diagnose LaunchDarkly SDK connectivity (init + events).")
+    p.add_argument("--instance", choices=list(INSTANCES),
+                   default="commercial", help="LaunchDarkly instance preset")
+    p.add_argument("--side", choices=["server", "client", "mobile"],
+                   default="server", help="SDK side to test")
+    p.add_argument("--relay", help="Relay Proxy base URI (overrides instance)")
+    p.add_argument("--stream-url", help="Override the streaming base URI")
+    p.add_argument("--poll-url", help="Override the polling base URI")
+    p.add_argument("--events-url", help="Override the events base URI")
+    p.add_argument("--sdk-key", help="SDK key (prefer --sdk-key-env; argv is "
+                   "visible in the process list and shell history)")
+    p.add_argument("--sdk-key-env", help="Name of env var holding the SDK key")
+    p.add_argument("--hold", type=int, default=30,
+                   help="Seconds to hold the stream open (0 to skip)")
+    p.add_argument("--timeout", type=float, default=10.0,
+                   help="Per-operation network timeout in seconds")
+    p.add_argument("--allow-insecure", action="store_true",
+                   help="Permit plaintext http:// targets (e.g. local relay)")
+    p.add_argument("--json", action="store_true", help="Emit JSON output")
+    p.add_argument("--no-color", action="store_true", help="Disable color")
+    p.add_argument("--version", action="version",
+                   version=f"ld-netcheck {VERSION}")
+    args = p.parse_args(argv)
+
+    results, env_c, key, side = run(args)
+    if args.json:
+        print_json(results, env_c, key, side, args)
+    else:
+        print_text(results, env_c, key, side, args)
+    return exit_code(results)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/support-network-diag-tool/ld_netcheck.py
+++ b/support-network-diag-tool/ld_netcheck.py
@@ -7,8 +7,7 @@ polling (init), and events endpoints, and explains how to unblock them when
 it cannot. Standard library only - no third-party dependencies.
 
 The checks and remediation mapping are grounded in the LaunchDarkly public
-domain list (https://launchdarkly.com/docs/sdk/concepts/domain-list) and the
-internal Network Troubleshooting Checklist failure modes:
+domain list (https://launchdarkly.com/docs/sdk/concepts/domain-list):
 
   401              -> SDK key missing/incorrect (auth, not network)
   403 / Forbidden  -> endpoint not allowlisted in firewall or CSP
@@ -43,10 +42,23 @@ VERSION = "1.0.0"
 # Paths used by the real SDKs for the initial flag payload and events.
 PATHS = {
     "server": {"stream": "/all", "poll": "/sdk/latest-all", "events": "/bulk"},
-    # Client/mobile init paths are context-specific; for a connectivity probe
+    # Client-side init paths are context-specific; for a connectivity probe
     # we hit the service root, which is enough to exercise DNS/TCP/TLS/HTTP.
-    "client": {"stream": "/eval", "poll": "/sdk/evalx", "events": "/bulk"},
-    "mobile": {"stream": "/meval", "poll": "/msdk/evalx", "events": "/mobile"},
+    "client": {"stream": "/eval", "poll": "/sdk/evalx", "poll_app": "/sdk/evalx",
+               "events": "/bulk"},
+}
+
+ENDPOINT_ORDER = {
+    "server": ("stream", "poll", "events"),
+    # JS clients may poll via clientsdk or app (domain list alternate).
+    "client": ("stream", "poll", "poll_app", "events"),
+}
+
+ENDPOINT_LABELS = {
+    "stream": "stream (init)",
+    "poll": "poll (init)",
+    "poll_app": "poll (app)",
+    "events": "events",
 }
 
 INSTANCES = {
@@ -56,10 +68,8 @@ INSTANCES = {
                    "events": "https://events.launchdarkly.com"},
         "client": {"stream": "https://clientstream.launchdarkly.com",
                    "poll": "https://clientsdk.launchdarkly.com",
+                   "poll_app": "https://app.launchdarkly.com",
                    "events": "https://events.launchdarkly.com"},
-        "mobile": {"stream": "https://clientstream.launchdarkly.com",
-                   "poll": "https://clientsdk.launchdarkly.com",
-                   "events": "https://mobile.launchdarkly.com"},
     },
     "eu": {
         "server": {"stream": "https://stream.eu.launchdarkly.com",
@@ -67,9 +77,7 @@ INSTANCES = {
                    "events": "https://events.eu.launchdarkly.com"},
         "client": {"stream": "https://clientstream.eu.launchdarkly.com",
                    "poll": "https://clientsdk.eu.launchdarkly.com",
-                   "events": "https://events.eu.launchdarkly.com"},
-        "mobile": {"stream": "https://clientstream.eu.launchdarkly.com",
-                   "poll": "https://clientsdk.eu.launchdarkly.com",
+                   "poll_app": "https://app.eu.launchdarkly.com",
                    "events": "https://events.eu.launchdarkly.com"},
     },
     "federal": {
@@ -78,9 +86,7 @@ INSTANCES = {
                    "events": "https://events.launchdarkly.us"},
         "client": {"stream": "https://clientstream.launchdarkly.us",
                    "poll": "https://clientsdk.launchdarkly.us",
-                   "events": "https://events.launchdarkly.us"},
-        "mobile": {"stream": "https://clientstream.launchdarkly.us",
-                   "poll": "https://clientsdk.launchdarkly.us",
+                   "poll_app": "https://app.launchdarkly.us",
                    "events": "https://events.launchdarkly.us"},
     },
 }
@@ -212,12 +218,6 @@ def check_tls(host, port, timeout):
                     issuer.get("commonName", "")
         c.status = PASS
         c.detail = f"{version}, cert issued by '{issuer_org or 'unknown'}'"
-        if version and version < "TLSv1.2":
-            c.status = WARN
-            c.detail += " (below TLS 1.2)"
-            c.suggestions.append(
-                "Negotiated TLS version is below 1.2. LaunchDarkly requires "
-                "modern TLS; update the client/proxy TLS configuration.")
         # Trusted, but issued by something we don't recognize as a public CA?
         if issuer_org and not _scan_markers(issuer_org, PUBLIC_CA_MARKERS):
             vendor = _scan_markers(issuer_org, INTERCEPTION_MARKERS)
@@ -326,7 +326,7 @@ def interpret_status(c, code, label, key, proxy):
         c.suggestions.append(
             f"404 on {label}. The path or instance may be wrong for this SDK "
             "type. Confirm you are testing the correct instance "
-            "(commercial/EU/federal) and SDK side (server/client/mobile).")
+            "(commercial/EU/federal) and SDK side (server/client).")
     elif code == 405:
         c.status = FAIL
         c.suggestions.append(
@@ -561,22 +561,27 @@ def check_env_proxy():
 # --- Orchestration ----------------------------------------------------------
 
 def build_targets(args):
-    targets = {}
+    side = args.side
+    preset = INSTANCES[args.instance][side]
     if args.relay:
         base = args.relay.rstrip("/")
         targets = {"stream": base, "poll": base, "events": base}
-        side = "server"
+        # Relay v9 uses streaming + polling through the proxy for init, but JS
+        # clients may still poll via app.
+        if side == "client":
+            targets["poll_app"] = (
+                args.poll_app_url or preset.get("poll_app"))
+    elif args.stream_url or args.poll_url or args.poll_app_url or args.events_url:
+        targets = {
+            "stream": args.stream_url or preset["stream"],
+            "poll": args.poll_url or preset["poll"],
+            "events": args.events_url or preset["events"],
+        }
+        if side == "client":
+            targets["poll_app"] = (
+                args.poll_app_url or preset.get("poll_app"))
     else:
-        side = args.side
-        if args.stream_url or args.poll_url or args.events_url:
-            preset = INSTANCES[args.instance][side]
-            targets = {
-                "stream": args.stream_url or preset["stream"],
-                "poll": args.poll_url or preset["poll"],
-                "events": args.events_url or preset["events"],
-            }
-        else:
-            targets = dict(INSTANCES[args.instance][side])
+        targets = dict(preset)
     return targets, side
 
 
@@ -594,13 +599,14 @@ def run(args):
     paths = PATHS[side]
     results = []
 
-    for kind in ("stream", "poll", "events"):
+    for kind in ENDPOINT_ORDER[side]:
+        if kind not in targets:
+            continue
         url = targets[kind]
         parts = urlsplit(url)
         host = parts.hostname
         port = parts.port or (443 if parts.scheme == "https" else 80)
-        label = {"stream": "stream (init)", "poll": "poll (init)",
-                 "events": "events"}[kind]
+        label = ENDPOINT_LABELS[kind]
         tr = TargetResult(label=label, url=url, host=host, port=port)
 
         dns_c, ok = check_dns(host, args.timeout)
@@ -707,11 +713,14 @@ def main(argv=None):
         description="Diagnose LaunchDarkly SDK connectivity (init + events).")
     p.add_argument("--instance", choices=list(INSTANCES),
                    default="commercial", help="LaunchDarkly instance preset")
-    p.add_argument("--side", choices=["server", "client", "mobile"],
-                   default="server", help="SDK side to test")
+    p.add_argument("--side", choices=["server", "client"],
+                   default="server",
+                   help="SDK side to test (server-side or client-side JS)")
     p.add_argument("--relay", help="Relay Proxy base URI (overrides instance)")
     p.add_argument("--stream-url", help="Override the streaming base URI")
-    p.add_argument("--poll-url", help="Override the polling base URI")
+    p.add_argument("--poll-url", help="Override the polling base URI (clientsdk)")
+    p.add_argument("--poll-app-url",
+                   help="Override the alternate polling base URI (app; client only)")
     p.add_argument("--events-url", help="Override the events base URI")
     p.add_argument("--sdk-key", help="SDK key (prefer --sdk-key-env; argv is "
                    "visible in the process list and shell history)")


### PR DESCRIPTION
## Summary

Adds `support-network-diag-tool`, a zero-dependency diagnostic for LaunchDarkly SDK connectivity issues. Customers can use this tool when an SDK won't initialize, the stream keeps reconnecting, or events aren't arriving.

The tool tests reachability to the streaming (init), polling (init), and events endpoints, runs layered checks (DNS → TCP → TLS → HTTP → stream hold), and maps failures to concrete remediation guidance grounded in the [domain list](https://launchdarkly.com/docs/sdk/concepts/domain-list).

Two tiers:
- **`ld_netcheck.py`** — Python 3.8+ (stdlib only); full diagnosis, JSON output, stream-hold test
- **`ld-netcheck-quick.sh`** — POSIX `sh` + `curl` for locked-down environments

Scope:
- **In scope:** server-side SDKs and client-side JavaScript (`--side server` / `--side client`)
- **Out of scope:** mobile SDKs (require device-native diagnostics)

Client-side JS checks all four endpoints: `clientstream`, `clientsdk`, `app`, and `events`. Relay mode routes stream/poll/events through the proxy while still testing `app` directly for allowlisting gaps.